### PR TITLE
ci: bump version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "channel-mixer",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "private": true,
   "author": "Leandro Junior",
   "description": "A simple and practical utility to mix grayscale textures into a single RGBA mask.",


### PR DESCRIPTION
Bump version in package.json
- Bumped to version: 1.0.0
- Auto-generated by Github Actions